### PR TITLE
Fixed bug with biomarker dropdown clipping on small widths

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
           >
           <select
             id="biomarker-select"
-            class="p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            class="p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 w-full max-w-xs sm:max-w-full truncate"
           ></select>
         </div>
 


### PR DESCRIPTION
Before:
<img width="405" height="195" alt="image" src="https://github.com/user-attachments/assets/c73bc05a-1800-4065-862f-e742134df55e">

After:
<img width="405" height="195" alt="image" src="https://github.com/user-attachments/assets/85502b97-1015-4dda-95e0-851a17cf5d3c" />

See a working demo at https://forrest22.github.io/biomarker_ref_intervals/
